### PR TITLE
Sanitize `FormatTags` coming from user input within GlueUI

### DIFF
--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/BattleMapInfoPanel.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/BattleMapInfoPanel.SC2Layout
@@ -159,6 +159,8 @@
             <Anchor side="Right" relative="$parent" pos="Max" offset="-17"/>
             <Style val="@CustomGames_MapInfoPreview_Title"/>
             <Visible val="False"/>
+            <AcceptsMouseTooltip val="true"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <Text val="{$parent/BattleMapFrame/@NameWithVersion}"/>
         </Frame>
         

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/BattleMapInfoTooltip.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/BattleMapInfoTooltip.SC2Layout
@@ -39,6 +39,8 @@
             <Anchor side="Right" relative="$parent" pos="Max" offset="-20"/>
             <Style val="@Arcade_GameInfo_Title"/>
             <Visible val="False"/>
+            <AcceptsMouseTooltip val="true"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <Text val="{$parent/BattleMapFrame/@NameWithVersion}"/>
         </Frame>
         

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/BattleMapProfileReviewsPanel.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/BattleMapProfileReviewsPanel.SC2Layout
@@ -129,7 +129,7 @@
             <Anchor side="Right" relative="$parent/AnchorFrame" pos="Max" offset="-15"/>
             <Style val="@Arcade_GameInfo_HowToPlay_Desc"/>
             <AutoSizeClamps minHeight="40"/>
-            <Options val="NewLineIfTruncated"/>
+            <Options val="NewLineIfTruncated | IgnoreWrapHints | IgnoreHyperlinks | IgnoreHotkeys | IgnoreImages | IgnoreData | IgnoreInfo | IgnoreSpaceTags | IgnoreKeys"/>
         </Frame>
 
         <Frame type="Label" name="TimeLabel">

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/CustomGameModListPanel.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/CustomGameModListPanel.SC2Layout
@@ -142,7 +142,7 @@
             <AutoSizeClamps maxWidth="700"/>
             <Style val="@Arcade_ListTitle_Normal"/>
             <AcceptsMouseTooltip val="true"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <Animation name="SelectedLabel" template="CustomGameModListPanel/SelectedLabelTemplate"/>
         </Frame>
 
@@ -286,7 +286,7 @@
             <Anchor side="Top" relative="$parent/TitleLabel" pos="Max" offset="55"/>
             <Anchor side="Left" relative="$parent/JoinListBG" pos="Min" offset="10"/>
             <Anchor side="Right" relative="$parent/JoinListBG" pos="Mid" offset="0"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <AcceptsMouseTooltip val="true"/>
             <Style val="@Arcade_GameInfo_Title"/>
             <Text val="{$this/BattleMapFrame/@Name}"/>

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/CustomGamesLobbies.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/CustomGamesLobbies.SC2Layout
@@ -326,7 +326,9 @@
             <Anchor side="Right" relative="$parent/TitleLabel" pos="Min" offset="-20"/>
             <Height val="20"/>
             <AcceptsMouseTooltip val="True"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <!-- Can't ignore all FormatTags in here, due to use of FormattedMapName to assemble "map_name + mod_name" by the use of embedded style tag -->
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreWrapHints | IgnoreHyperlinks | IgnoreHotkeys | IgnoreImages | IgnoreData | IgnoreInfo | IgnoreSpaceTags | IgnoreKeys"/>
+            <TooltipFrame val="LobbyItemLabelTooltip"/>
  
             <Frame type="TextFormatFrame" name="FormattedMapName">
                 <Anchor relative="$parent"/>
@@ -469,7 +471,8 @@
             <Style val="@CustomGames_ListItem_Normal"/>
             <Text val="{$parent/@LobbyName}"/>
             <AcceptsMouseTooltip val="True"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
+            <TooltipFrame val="LobbyItemLabelTooltip"/>
             
             <StateGroup name="VisibleState">
                 <DefaultState val="NotVisible"/>
@@ -728,6 +731,8 @@
             <Anchor side="Right" relative="$parent" pos="Max" offset="0"/>
             <AcceptsMouse val="true"/>
             <RequireSelection val="true"/>
+
+            <Frame type="StandardTooltip" name="LobbyItemLabelTooltip" template="CustomGamesTemplates/BattleUserInputTooltip"/>
             
             <Frame type="LobbyTileListItem" name="Item0" template="CustomGamesLobbies/LobbyListItemTemplate">
                 <Frame type="Frame" name="AnchorFrame">

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/CustomGamesTemplates.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/CustomGamesTemplates.SC2Layout
@@ -168,8 +168,33 @@
             </Controller>
         </Animation>
     </Frame>
-    
-    
+
+
+    <!-- 
+    ========================
+    BATTLEUSERINPUTTOOLTIP
+    ========================
+    -->
+    <Frame type="StandardTooltip" name="BattleUserInputTooltip" template="StandardTooltip/StandardTooltip">
+        <Frame type="Label" name="Label">
+            <Options val="StripFormatTags | NewLineIfTruncated"/>
+        </Frame>
+
+        <StateGroup name="VisibilityState">
+            <DefaultState val="Invisible"/>
+
+            <State name="Visible">
+                <When type="Property" frame="$this/Label" operator="NotEqual" Text=""/>
+            </State>
+
+            <State name="Invisible">
+                <Action type="SetProperty" frame="$this/BackgroundImage" Visible="False"/>
+                <Action type="SetProperty" frame="$this/Label" Alpha="0"/>
+            </State>
+        </StateGroup>
+    </Frame>
+
+
     <!-- 
     ========================
     BATTLEMAPINFOPANEL
@@ -200,7 +225,7 @@
             <Style val="@CustomGames_MapInfoPreview_Title"/>
             <Text val="{$parent/BattleMapFrame/@Name}"/>
             <AcceptsMouse val="True"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="NewLineIfTruncated | IgnoreFormatTags"/>
             
             <StateGroup name="VisibleState">
                 <DefaultState val="NotVisible"/>
@@ -1260,6 +1285,8 @@
     -->
     <Frame type="BookmarkSelectionTileListItem" name="BookmarkSelectionTileListItemTemplate" template="StandardTileListTemplates/StandardSmallTileListItemTemplate">
         <HideWhenCleared val="False"/>
+
+        <Frame type="StandardTooltip" name="LobbyItemLabelTooltip" template="CustomGamesTemplates/BattleUserInputTooltip"/>
         
         <Frame type="Frame" name="AnchorFrame">
             <Anchor side="Left" relative="$parent/$parent" pos="Min" offset="16"/>
@@ -1364,6 +1391,9 @@
             <Anchor side="Left" relative="$parent/BattleMapIcon" pos="Max" offset="10"/>
             <Anchor side="Right" relative="$parent/BookmarkIcon" pos="Min" offset="-10"/>
             <Height val="22"/>
+            <!-- Can't ignore all FormatTags in here, due to use of FormattedMapName to assemble "map_name + mod_name" by the use of embedded style tag -->
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreWrapHints | IgnoreHyperlinks | IgnoreHotkeys | IgnoreImages | IgnoreData | IgnoreInfo | IgnoreSpaceTags | IgnoreKeys"/>
+            <TooltipFrame val="LobbyItemLabelTooltip"/>
  
             <Frame type="TextFormatFrame" name="FormattedMapName">
                 <Anchor relative="$parent"/>
@@ -2468,6 +2498,9 @@
             <Anchor side="Right" relative="$parent/TitleLabel" pos="Min" offset="-10"/>
             <Height val="22"/>
             <Style val="@CustomGames_ListItem_Normal"/>
+            <!-- Can't ignore all FormatTags in here, due to use of FormattedMapName to assemble "map_name + mod_name" by the use of embedded style tag -->
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreWrapHints | IgnoreHyperlinks | IgnoreHotkeys | IgnoreImages | IgnoreData | IgnoreInfo | IgnoreSpaceTags | IgnoreKeys"/>
+            <TooltipFrame val="LobbyItemLabelTooltip"/>
  
             <Frame type="TextFormatFrame" name="FormattedMapName">
                 <Anchor relative="$parent"/>

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/LobbyGameInfoFrame.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/LobbyGameInfoFrame.SC2Layout
@@ -122,7 +122,7 @@
             <Anchor side="Top" relative="$parent/ScreenshotTileList" pos="Max" offset="10"/>
             <Anchor side="Left" relative="$parent/ScreenshotTileList" pos="Min" offset="0"/>
             <Anchor side="Right" relative="$parent/ScreenshotTileList" pos="Max" offset="0"/>
-            <Options val="Ellipsis | TooltipIfTruncated"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <AcceptsMouse val="True"/>
             <Height val="30"/>
         </Frame>
@@ -133,7 +133,7 @@
             <Anchor side="Right" relative="$parent/ScreenshotTileList" pos="Max" offset="0"/>
             <Height val="30"/>
             <AcceptsMouse val="True"/>
-            <Options val="Ellipsis | TooltipIfTruncated"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <Style val="@Lobby_MapInfoPreview_Title"/>
             <Text val="{$parent/BattleMapFrame/@Name}"/>
         </Frame>

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/LobbyListTemplates.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/LobbyListTemplates.SC2Layout
@@ -193,7 +193,9 @@
             <Anchor side="Right" relative="$parent/TitleLabel" pos="Min" offset="-20"/>
             <Height val="20"/>
             <AcceptsMouseTooltip val="True"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <!-- Can't ignore all FormatTags in here, due to use of FormattedMapName to assemble "map_name + mod_name" by the use of embedded style tag -->
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreWrapHints | IgnoreHyperlinks | IgnoreHotkeys | IgnoreImages | IgnoreData | IgnoreInfo | IgnoreSpaceTags | IgnoreKeys"/>
+            <TooltipFrame val="MapLobbyItemLabelTooltip"/>
  
             <Frame type="TextFormatFrame" name="FormattedMapName">
                 <Anchor relative="$parent"/>
@@ -259,6 +261,8 @@
             <Height val="20"/>
             <Style val="@CustomGames_ListItem_Normal"/>
             <Text val="{$parent/@LobbyName}"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
+            <TooltipFrame val="MapLobbyItemLabelTooltip"/>
             
             <StateGroup name="StyleState">
                 
@@ -498,6 +502,8 @@
         <Anchor side="Right" relative="$parent" pos="Max" offset="0"/>
         <AcceptsMouse val="true"/>
         <RequireSelection val="true"/>
+
+        <Frame type="StandardTooltip" name="MapLobbyItemLabelTooltip" template="CustomGamesTemplates/BattleUserInputTooltip"/>
 
         <Frame type="Label" name="MapNameHeaderLabel">
             <Anchor side="Top" relative="$parent" pos="Min" offset="22"/>

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ReportDialogs.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ReportDialogs.SC2Layout
@@ -35,6 +35,7 @@
         <Frame type="Label" name="TitleLabel">
             <Anchor side="Top" relative="$parent/DialogTitleLabel" pos="Max" offset="5"/>
             <Style val="@Arcade_ReportDialog_SubTitle"/>
+            <Options val="IgnoreFormatTags"/>
         </Frame>
 
         <Frame type="Label" name="DescriptionLabel">

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ScreenBattleLobby.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ScreenBattleLobby.SC2Layout
@@ -155,7 +155,8 @@
             <AutoSizeClamps maxWidth="430"/>
             <Style val="@Lobby_Title"/>
             <AcceptsMouseTooltip val="true"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | NoWrapping | StripFormatTags"/>
+            <!-- ideally we'd want <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/> ; but that wouldn't strip text tags from the tooltip -->
             <Text val="{$parent/MapFrame/@Name}"/>
             <PreserveAnchorOffset val="True"/>
         </Frame>
@@ -176,7 +177,8 @@
             <AutoSizeClamps maxWidth="340"/>
             <Style val="@Lobby_ModTitle"/>
             <AcceptsMouseTooltip val="true"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | NoWrapping | StripFormatTags"/>
+            <!-- ideally we'd want <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/> ; but that wouldn't strip text tags from the tooltip -->
             <Text val="{$parent/ModFrame/@Name}"/>
             <CollapseLayout val="true"/>
 
@@ -217,7 +219,8 @@
             <AutoSizeClamps maxWidth="430"/>
             <Style val="@Lobby_Name"/>
             <AcceptsMouseTooltip val="true"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | NoWrapping | StripFormatTags"/>
+            <!-- ideally we'd want <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/> ; but that wouldn't strip text tags from the tooltip -->
             <Text val="{$parent/@LobbyName}"/>
             <PreserveAnchorOffset val="True"/>
                 

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ScreenBattleMapProfile.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ScreenBattleMapProfile.SC2Layout
@@ -284,7 +284,7 @@
             <Anchor side="Left" relative="$parent/ArcadeMapIcon/IconImage" pos="Max" offset="15"/>
             <Style val="@Arcade_GameInfo_Title"/>
             <AcceptsMouseTooltip val="true"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | NoWrapping | IgnoreFormatTags"/>
             <PreserveAnchorOffset val="False"/>
             <AutoSizeClamps maxWidth="700"/>
             <Text val="{$ScreenBattleMapProfile/BattleMapFrame/@Name}"/>

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ScreenScore.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/ScreenScore.SC2Layout
@@ -117,7 +117,7 @@
                 <AutoSizeClamps maxWidth="265"/>
                 <Style val="@Lobby_Title"/>
                 <AcceptsMouseTooltip val="true"/>
-                <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+                <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
                 <Text val="{$parent/MapFrame/@Name}"/>
             </Frame>
         
@@ -142,7 +142,7 @@
                 <AutoSizeClamps maxWidth="265"/>
                 <Style val="@Lobby_ModTitle"/>
                 <AcceptsMouseTooltip val="true"/>
-                <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+                <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
                 <Text val="{$parent/ModFrame/@Name}"/>
                 <CollapseLayout val="true"/>
 

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/UserProfileMapReviewsFrame.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/UserProfileMapReviewsFrame.SC2Layout
@@ -91,6 +91,7 @@
             <Anchor side="Left" relative="$parent/MapIcon" pos="Max" offset="10"/>
             <Anchor side="Right" relative="$parent/HelpfulLabel" pos="Min" offset="-10"/>
             <Style val="@Arcade_GameInfo_Reviews_Author"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <Text val="{$this/MapFrame/@Name}"/>
 
             <Frame type="BattleMapFrame" name="MapFrame">
@@ -134,7 +135,7 @@
             <Anchor side="Right" relative="$parent/AnchorFrame" pos="Max" offset="-15"/>
             <Style val="@Arcade_GameInfo_HowToPlay_Desc"/>
             <AutoSizeClamps minHeight="40"/>
-            <Options val="NewLineIfTruncated"/>
+            <Options val="NewLineIfTruncated | IgnoreWrapHints | IgnoreHyperlinks | IgnoreHotkeys | IgnoreImages | IgnoreData | IgnoreInfo | IgnoreSpaceTags | IgnoreKeys"/>
         </Frame>
 
         <Frame type="Label" name="TimeLabel">

--- a/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/UserProfileMatchHistoryFrame.SC2Layout
+++ b/mods/core.sc2mod/base.sc2data/UI/Layout/Glue/UserProfileMatchHistoryFrame.SC2Layout
@@ -65,6 +65,7 @@
         <Frame type="Label" name="ModNameLabel">
             <Anchor relative="$parent"/>
             <Visible val="false"/>
+            <Options val="IgnoreFormatTags"/>
 
             <StateGroup name="ModStateGroup">
                 <DefaultState val="ExtensionModState"/>
@@ -112,7 +113,7 @@
             <Anchor side="Right" relative="$parent/ModeLabel" pos="Min" offset="-10"/>
             <Style val="Profile_MatchHistory_ListItem_Title"/>
             <AcceptsMouseTooltip val="false"/>
-            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping"/>
+            <Options val="Ellipsis | TooltipIfTruncated | NoWrapping | IgnoreFormatTags"/>
             <Text val="{$parent/NameFormatFrame/@Text}"/>
         </Frame>
 


### PR DESCRIPTION
## About the bug

- https://gist.github.com/Talv/d8d3f399e21648c03c96d0c9dbd9d9b8
- https://us.forums.blizzard.com/en/sc2/t/new-arcade-review-crasher/27147
- [... any many other reports ...]

## About the patch

This patch attempts to sanitize [Text Tags / Format Tags](https://sc2mapster.fandom.com/wiki/Text_Tags#Image) in various places of GlueUI. Most importantly within in `Map Reviews View`, `User Reviews View`, `Custom Game Lobbies View` - as these views did have most of the impact, and were most often abused.

However, it's not the only `View` that's affected by this where user input could be sneaked. It mostly impacts views and specifically "components"/"frames" that use `BattleMapFrame` in order to resolve map information, which is then property bound directly to a `Label` without any sanitization, resulting in `Format Tags` being applied. Thus I very much doubt that I've covered all the places, but I did try to cover most important spots.

While preparing this patch the major difficulty I've run into is sanitizing `Tooltip` of a `Label` frame that uses a `Option`s flag called `TooltipIfTruncated`, that behind the scenes pulls up the `StandardTooltip` frame, and directly copies the `Text` of truncated `Label` to `Label` within tooltip, but without sanitizing the text it contains. Due to following problem I had to use some non-standard solutions that made this patch more complex than I've hoped it'd be.

There was also a lot of places in `SC2Layout` where code was repeated and not properly templated, but I made no attempts at refactoring it, and did continue to copy-paste stuff to make it easier to review, and prevent unwanted implications of my changes.

**This is a gallery in regards to what to expect: https://imgur.com/a/3A8HBCR** (order in which I made the screenshots is totally arbitrary).

### About QA

These patches weren't made blindly, but the tools I've at my disposal doesn't make the workflow exactly convenient, so please review it.

I'm confident they don't break any existing functionality, what I'm not confident of is about impact of these changes from the UX side (due to removal of `TooltipIfTruncated` from few places), and localizations other than `enUS`.

If I had some more free time I'd polish it further and done more tests / ask someone else to review, but if today's day was the deadline, then that's all I can offer.

### What it doesn't fix

Things that must be done from code:

- Ensure `img` can only `path` to:
  - cache directory of SC2
  - CASC assets
  - currently loaded map/mod's assets
- Do the same when it comes to `Texture` of an `Image` frame, to prevent abuse of text tags within custom games.

### Future recommendations

Above problem may also apply to other frames that accept a direct filepath in some form (`FlashFrame` + `File` possibly?) etc. but I feel like it's a topic for different issue.

I'd also look at various map related frames. Like `CBattleMapFrame/@Description` etc.

Thus far we only seen `FormatTags` being abused within the `Name` field, but personally I haven't tested if the same can't be acomplished by using `Description`.

### Further comments

While this patch attempts to preserve `Format Tags` in map reviews (with the exception of `<img>`, `<d>`, `<a>` tags that have been exploited in the past in various ways). I believe the `<s>`, and `<c>` tags have no known exploits (I've tested various use of `validator` parameter under them, but seems like this angle is covered - wasn't able to exploit myself), so I left them to be there.

Yet it might not be a good idea in the long run. There's consensus among map makers that these `FormatTags` have high potential to abuse, and I'd recommend you to consider suppressing them COMPLETELY in reviews, considering how long it takes for the current crew to address actual issue that involves them, and then actually get it shipped.

I'm not sure if it was ever intended for them to be allowed there (it wasn't in `WoL`, possibly early `HotS` - can't recall exact date of the UI revamp that introduced this "feature"). This "feature" came later, but it's very likely that it was unintended, and not something made by design.

Also, let's not forget the classic from the past:

https://us.forums.blizzard.com/en/sc2/t/sc2-arcade-map-review-player-name-reference-crasher/25606/2

> It’s already spread fairly rapidly, and I’m afraid that soon, most players won’t be able to check the reviews of most games anymore because of this client crasher.

![](https://i.imgur.com/gwCga4U.png)

### Some examples

```html
H.<img path="//a.io/_"/><img path="//b.io/_"/><img path="//c.io/_"/><img path="//d.io/_"/><img path="//e.io/_"/><img path="//g.io/_"/><img path="//h.io/_"/><img path="//i.io/_"/><img path="//j.io/_"/><img path="//k.io/_"/><img path="//l.io/_"/><img path="//m.io/_"/><img path="//p.io/_"/><img path="//q.io/_"/><img path="//s.io/_"/><img path="//u.io/_"/><img path="//w.io/_"/><img path="//x.io/_"/><img path="//y.io/_"/><img path="//z.io/_"/><img path="//a.co/_"/><img path="//c.co/_"/><img path="//d.co/_"/><img path="//f.co/_"/><img path="//g.co/_"/><img path="//i.co/_"/><img path="//j.co/_"/><img path="//l.co/_"/><img path="//m.co/_"/><img path="//n.co/_"/><img path="//o.co/_"/><img path="//p.co/_"/><img path="//r.co/_"/><img path="//s.co/_"/><img path="//t.co/_"/><img path="//u.co/_"/><img path="//v.co/_"/><img path="//w.co/_"/><img path="//x.co/_"/><img path="//a.ai/_"/><img path="//c.ai/_"/><img path="//d.ai/_"/><img path="//e.ai/_"/><img path="//f.ai/_"/><img path="//g.ai/_"/><img path="//h.ai/_"/>V.
```

```html
<img path="//ü/ü"/><img path="//é/é"/><img path="//ï/ï"/><img path="//Ä/Ä"/><img path="//Æ/Æ"/><img path="//ô/ô"/><img path="//Ñ/Ñ"/><img path="//Σ/Σ"/><img path="//Ω/Ω"/><img path="//δ/δ"/><img path="//Φ/Φ"/><img path="//Θ/Θ"/><img path="//τ/τ"/><img path="//π/π"/><img path="//ß/ß"/><img path="//-/-"/><img path="///"/><img path="//0/0"/><img path="//1/1"/><img path="//2/2"/><img path="//3/3"/><img path="//4/4"/><img path="//5/5"/><img path="//6/6"/><img path="//7/7"/><img path="//8/8"/><img path="//9/9"/><img path="//a/a"/><img path="//b/b"/><img path="//c/c"/><img path="//d/d"/><img path="//e/e"/><img path="//f/f"/><img path="//g/g"/><img path="//h/h"/><img path="//i/i"/><img path="//j/j"/><img path="//k/k"/><img path="//l/l"/><img path="//m/m"/><img path="//n/n"/><img path="//o/o"/><img path="//p/p"/><img path="//q/q"/><img path="//r/r"/><img path="//s/s"/><img path="//t/t"/><img path="//u/u"/><img path="//v/v"/><img path="//w/w"/><img path="//x/x"/><img path="//y/y"/><img path="//z/z"/>
```

```html
<img path="//localhost/c$/programdata/blizzard entertainment/battle.net/cache/3e/cd/3ecdfc026de00c57cd570793aec91c6b103abd11e1dfaed8b22a7fb6a6907110.wafl" alignment="AbsoluteMiddle" resolution="discrete" entrydims="1,0" texsheet="8,8,1" texanim="[d ref='64'/],[d ref='1000'/]" width="256" height="256"/>   <img path="//localhost/c$/programdata/blizzard entertainment/battle.net/cache/0a/b6/0ab67f9458e40c689371232f2c4dd387054bbdf3a9f59b1cdc495b57528f2a40.wafl" alignment="AbsoluteMiddle" resolution="discrete" entrydims="1,0" texsheet="8,8,1" texanim="[d ref='64'/],[d ref='1600'/]" width="256" height="256"/>
```

```html
<a name="WebsiteUrl" href="[bnet:local/0.0/350493]1">click</a>
<a name="WebsiteUrl" href="//https://stopify.co/727DWD.jpg">CLICK ME</a>
<a name="WebsiteUrl" href="https://stopify.co/727DWD.jpg">CLICK ME</a>
<a name="WebsiteUrl" href="stopify.co/727DWD.jpg">CLICK ME</a>
<a name="WebsiteUrl" href="stopify.co/727DWD">CLICK ME</a>

<!-- ^ doesn't work in `Label` that aren't setup for it (`AcceptsMouse` , `Hookup` as a `Control` element? etc.? not sure) -->
```

```html
<a name="WebsiteUrl" href="\\.\globalroot\device\condrv\kernelconnect">CLICK ME</a>

for he is watchful...


<img path="Assets\Textures\femalecivilian5portrait_diff.dds" texcoords="0,0.5,0.35,0.8" />
<img path="Assets\Textures\femalecivilian5portrait_diff.dds"width="1024" height="1024"  texcoords="0.35,0.6,0.44,0.685" /> <sp/> <img path="Assets\Textures\femalecivilian5portrait_diff.dds"width="1024" height="1024"  texcoords="0.35,0.6,0.44,0.685" />

<img path="\\.GLOBALROOT\Device\ConDrv\KernelConnect"/>
<img path="\\.\globalroot\device\condrv\kernelconnect"/>
<img path="///GLOBALROOT/Device/ConDrv/KernelConnect"/>
<img path="//GLOBALROOT/Device/ConDrv/KernelConnect"/>
<img path="file://///GLOBALROOT/Device/ConDrv/KernelConnect"/>
<img path="C:/../.."/>
<img path="C:\..\.."/>
<img path="C:\.\"/>
<img path="C:\con\con"/>
<img path="C:\nul"/>
<img path="C:\Windows\system32\conhost.exe\"/>
<img path="C:\$MFT\123"/>
<img path="C:\Windows\clock$"/>

<!-- https://learn.microsoft.com/en-us/answers/questions/235907/windows-crash-when-navigate-globalrootdevicecondrv -->
<!-- (doesn't work) -->
```

```html
<d Player="0" GameValue="PlayerName"/> <!-- patched in the past -->
<d ref="Effect,GuassRifle,Amount"precision="1"/> instead of <d ref="Effect,GuassRifle,Amount"/> <!-- ? -->
```

```html
<img path="C:\Windows\Web\Wallpaper\Windows\img0.jpg" alignment="absolutemiddle"/>
```

```html
<img path="C:\[k val='%'/]AppData[k val='%'/]\Microsoft\Windows\Themes\CachedFiles\CachedImage_3840_2160_POS4.jpg"/>

C:\&#37;AppData[d ref='&#37;'/]\Microsoft\Windows\Themes\CachedFiles\CachedImage_3840_2160_POS4.jpg
[k val='&#37;'/]
<d ref="[d ref='&#37;'/]"/>

&#37;
<d Time="DateTime"/>
<d ref="[d ref='340282356999999999999999999999999999999'/]"/>
<d ref="[d ref='340282357000000000000000000000000000000'/]"/>
<d ref="340282366920938463463374607431768211456" precision="100"/>
<d ref="340282366920938463463374607431768211456*0." precision="100"/>

<!-- ???? -->
```

```html
<d StringRef="GameUI,Dflt,LoadingScreenHelp[0].Text"/>
<d StringRef="GameUI,Dflt,HelpGameMechanics[9].Description"/>
```

---

More: https://sc2mapster.fandom.com/wiki/Text_Tags

It only documents *known* ways of using text tags.